### PR TITLE
Prevent an IndexError if we get malformed headers

### DIFF
--- a/tastypie_oauth/authentication.py
+++ b/tastypie_oauth/authentication.py
@@ -49,8 +49,10 @@ class OAuth20Authentication(Authentication):
                 for header in ['Authorization', 'HTTP_AUTHORIZATION']:
                     auth_header_value = request.META.get(header)
                     if auth_header_value:
-                        key = auth_header_value.split(' ', 1)[1]
-                        break
+                        tokens = auth_header_value.split(' ', 1)
+                        if len(tokens) == 2:  # Avoid an IndexError in case of malformed header
+                            key = tokens[1]
+                            break
             if not key and request.method == 'POST':
                 if request.META.get('CONTENT_TYPE') == 'application/json':
                     decoded_body = request.body.decode('utf8')


### PR DESCRIPTION
It's been happening now and then, perhaps when people run scripts without proper authentication. But that doesn't mean we should crash.
PM item: https://sync.appfluence.com/native/api/v1/item/278926265/
Issue: https://sentry.prioritymatrix.com/organizations/appfluence/issues/765